### PR TITLE
Handle withdraw errors via RemoveAmount and lock balance read

### DIFF
--- a/src/handlers/withdraw.go
+++ b/src/handlers/withdraw.go
@@ -32,16 +32,18 @@ func Withdraw(c *gin.Context) {
 		return
 	}
 
-	if account.Balance < req.Amount {
+	if err := logic.RemoveAmount(account, req.Amount); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Saldo insuficiente"})
 		return
 	}
 
-	logic.RemoveAmount(account, req.Amount)
+	account.Mu.Lock()
+	balance := account.Balance
+	account.Mu.Unlock()
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Saque realizado com sucesso",
 		"id":      account.Id,
-		"balance": account.Balance,
+		"balance": balance,
 	})
 }


### PR DESCRIPTION
## Summary
- use `logic.RemoveAmount` to validate withdrawals and handle insufficient balance errors
- lock account mutex when reading balance in withdraw handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894d29ff9a083249fcad94b842623ac