### PR TITLE
Lock balance before deposit response

### DIFF
--- a/src/handlers/deposit.go
+++ b/src/handlers/deposit.go
@@ -31,10 +31,15 @@ func Deposit(c *gin.Context) {
 		return
 	}
 
-	logic.AddAmount(account, req.Amount)
+	if err := logic.AddAmount(account, req.Amount); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	balance := logic.GetBalance(account)
 
 	c.JSON(http.StatusOK, gin.H{
 		"id":      account.Id,
-		"balance": account.Balance,
+		"balance": balance,
 	})
 }


### PR DESCRIPTION
## Summary
- read updated account balance under lock when returning deposit response

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894db36f180832495c4f67bf0553be3