### PR TITLE
Use read lock for account retrieval

### DIFF
--- a/src/db/inMemoryDB.go
+++ b/src/db/inMemoryDB.go
@@ -38,8 +38,8 @@ func (db *InMemoryDB) CreateAccount(owner string) int {
 }
 
 func (db *InMemoryDB) GetAccount(id int) (*models.Account, bool) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
+	db.mu.RLock()
+	defer db.mu.RUnlock()
 
 	account, ok := db.accounts[id]
 	return account, ok


### PR DESCRIPTION
## Summary
- Improve concurrent access by using an `RWMutex` read lock in `GetAccount` while keeping write locks on modifying operations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894dce6c6d48324a2cea0234e9a7131