### PR TITLE
Prevent transfers to the same account

### DIFF
--- a/src/handlers/transfer.go
+++ b/src/handlers/transfer.go
@@ -18,6 +18,11 @@ func Transfer(c *gin.Context) {
 		return
 	}
 
+	if req.FromID == req.ToID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Não é possível transferir para a mesma conta"})
+		return
+	}
+
 	from, ok := db.InMemory.GetAccount(req.FromID)
 	if !ok {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Conta de origem não encontrada"})

--- a/tests/integration/account/self_transfer_test.go
+++ b/tests/integration/account/self_transfer_test.go
@@ -1,0 +1,42 @@
+package account
+
+import (
+	"bank-api/src/db"
+	"bank-api/tests/integration/testenv"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTransferToSameAccount(t *testing.T) {
+	testenv.SetupRouter()
+	defer db.InMemory.Reset()
+
+	accountID := testenv.CreateAccount(t, "Self")
+	testenv.Deposit(t, accountID, 1000)
+
+	body := map[string]int{
+		"from":   accountID,
+		"to":     accountID,
+		"amount": 500,
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest("POST", "/accounts/transfer", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	testenv.SetupRouter().ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("esperado status %d, obtido %d", http.StatusBadRequest, resp.Code)
+	}
+
+	balance := testenv.GetBalance(t, accountID)
+	expected := 1000
+	if balance != expected {
+		t.Fatalf("esperado saldo %d, obtido %d", expected, balance)
+	}
+}


### PR DESCRIPTION
## Summary
- reject transfer requests when origin and destination accounts are the same
- add integration test covering self-transfer attempts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894de49208c8324871ad169190b0fb5