### PR TITLE
test: check response codes in concurrent account tests

### DIFF
--- a/tests/integration/account/concurrent_transfer_test.go
+++ b/tests/integration/account/concurrent_transfer_test.go
@@ -5,6 +5,7 @@ import (
 	"bank-api/tests/integration/testenv"
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -41,6 +42,10 @@ func TestConcurrentTransfer(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			testenv.SetupRouter().ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Errorf("Erro na transferência: %d", resp.Code)
+			}
 		}()
 	}
 

--- a/tests/integration/account/withdraw_test.go
+++ b/tests/integration/account/withdraw_test.go
@@ -63,6 +63,10 @@ func TestConcurrentWithdraw(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			testenv.SetupRouter().ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Errorf("Erro no saque: %d", resp.Code)
+			}
 		}()
 	}
 


### PR DESCRIPTION
## Summary
- ensure concurrent withdraw requests log HTTP failures
- validate response codes during concurrent transfer tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894dfdfb76c8324a9179ef2f3941465