### PR TITLE
Persist account updates to in-memory DB after transactions

### DIFF
--- a/src/db/inMemoryDB.go
+++ b/src/db/inMemoryDB.go
@@ -45,6 +45,13 @@ func (db *InMemoryDB) GetAccount(id int) (*models.Account, bool) {
 	return account, ok
 }
 
+func (db *InMemoryDB) UpdateAccount(acc *models.Account) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	db.accounts[acc.Id] = acc
+}
+
 func (db *InMemoryDB) Reset() {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/src/handlers/deposit.go
+++ b/src/handlers/deposit.go
@@ -36,6 +36,8 @@ func Deposit(c *gin.Context) {
 		return
 	}
 
+	db.InMemory.UpdateAccount(account)
+
 	balance := logic.GetBalance(account)
 
 	c.JSON(http.StatusOK, gin.H{

--- a/src/handlers/transfer.go
+++ b/src/handlers/transfer.go
@@ -53,6 +53,9 @@ func Transfer(c *gin.Context) {
 	from.Balance -= req.Amount
 	to.Balance += req.Amount
 
+	db.InMemory.UpdateAccount(from)
+	db.InMemory.UpdateAccount(to)
+
 	c.JSON(http.StatusOK, gin.H{
 		"message":      "Transferência realizada com sucesso",
 		"from_balance": from.Balance,

--- a/src/handlers/withdraw.go
+++ b/src/handlers/withdraw.go
@@ -37,9 +37,9 @@ func Withdraw(c *gin.Context) {
 		return
 	}
 
-	account.Mu.Lock()
-	balance := account.Balance
-	account.Mu.Unlock()
+	db.InMemory.UpdateAccount(account)
+
+	balance := logic.GetBalance(account)
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Saque realizado com sucesso",


### PR DESCRIPTION
## Summary
- add UpdateAccount to in-memory DB to persist modified accounts
- update deposit, withdraw and transfer handlers to save accounts after operations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894d1319c948324b186743de6a1fa33