### PR TITLE
feat: broadcast transaction events over SSE

### DIFF
--- a/src/diplomat/events/broker.go
+++ b/src/diplomat/events/broker.go
@@ -1,0 +1,60 @@
+package events
+
+import "bank-api/src/models"
+
+// Broker manages client subscriptions and broadcasts transaction events.
+type Broker struct {
+	clients       map[chan models.TransactionEvent]bool
+	newClients    chan chan models.TransactionEvent
+	closedClients chan chan models.TransactionEvent
+	events        chan models.TransactionEvent
+}
+
+// BrokerInstance is the global event broker.
+var BrokerInstance = NewBroker()
+
+// NewBroker creates and starts a new Broker.
+func NewBroker() *Broker {
+	b := &Broker{
+		clients:       make(map[chan models.TransactionEvent]bool),
+		newClients:    make(chan chan models.TransactionEvent),
+		closedClients: make(chan chan models.TransactionEvent),
+		events:        make(chan models.TransactionEvent),
+	}
+
+	go b.start()
+	return b
+}
+
+func (b *Broker) start() {
+	for {
+		select {
+		case client := <-b.newClients:
+			b.clients[client] = true
+		case client := <-b.closedClients:
+			delete(b.clients, client)
+			close(client)
+		case event := <-b.events:
+			for client := range b.clients {
+				client <- event
+			}
+		}
+	}
+}
+
+// Subscribe registers a new listener and returns its channel.
+func (b *Broker) Subscribe() chan models.TransactionEvent {
+	ch := make(chan models.TransactionEvent)
+	b.newClients <- ch
+	return ch
+}
+
+// Unsubscribe removes a listener.
+func (b *Broker) Unsubscribe(ch chan models.TransactionEvent) {
+	b.closedClients <- ch
+}
+
+// Publish sends the given event to all connected clients.
+func (b *Broker) Publish(event models.TransactionEvent) {
+	b.events <- event
+}

--- a/src/diplomat/routes/routes.go
+++ b/src/diplomat/routes/routes.go
@@ -14,4 +14,6 @@ func RegisterRoutes(router *gin.Engine) {
 	router.POST("/accounts/:id/withdraw", handlers.Withdraw)
 
 	router.POST("/accounts/transfer", handlers.Transfer)
+
+	router.GET("/events", handlers.Events)
 }

--- a/src/handlers/deposit.go
+++ b/src/handlers/deposit.go
@@ -2,9 +2,12 @@ package handlers
 
 import (
 	"bank-api/src/diplomat/database"
+	"bank-api/src/diplomat/events"
 	"bank-api/src/domain"
+	"bank-api/src/models"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -39,6 +42,14 @@ func Deposit(c *gin.Context) {
 	database.Repo.UpdateAccount(account)
 
 	balance := domain.GetBalance(account)
+
+	events.BrokerInstance.Publish(models.TransactionEvent{
+		Type:      "deposit",
+		AccountID: account.Id,
+		Amount:    req.Amount,
+		Balance:   balance,
+		Timestamp: time.Now(),
+	})
 
 	c.JSON(http.StatusOK, gin.H{
 		"id":      account.Id,

--- a/src/handlers/events.go
+++ b/src/handlers/events.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"bank-api/src/diplomat/events"
+	"io"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Events(c *gin.Context) {
+	ch := events.BrokerInstance.Subscribe()
+	defer events.BrokerInstance.Unsubscribe(ch)
+
+	c.Stream(func(w io.Writer) bool {
+		if evt, ok := <-ch; ok {
+			c.SSEvent("transaction", evt)
+			return true
+		}
+		return false
+	})
+}

--- a/src/handlers/transfer.go
+++ b/src/handlers/transfer.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"bank-api/src/diplomat/database"
+	"bank-api/src/diplomat/events"
+	"bank-api/src/models"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -55,6 +58,16 @@ func Transfer(c *gin.Context) {
 
 	database.Repo.UpdateAccount(from)
 	database.Repo.UpdateAccount(to)
+
+	events.BrokerInstance.Publish(models.TransactionEvent{
+		Type:        "transfer",
+		FromID:      from.Id,
+		ToID:        to.Id,
+		Amount:      req.Amount,
+		FromBalance: from.Balance,
+		ToBalance:   to.Balance,
+		Timestamp:   time.Now(),
+	})
 
 	c.JSON(http.StatusOK, gin.H{
 		"message":      "Transferência realizada com sucesso",

--- a/src/handlers/withdraw.go
+++ b/src/handlers/withdraw.go
@@ -2,9 +2,12 @@ package handlers
 
 import (
 	"bank-api/src/diplomat/database"
+	"bank-api/src/diplomat/events"
 	"bank-api/src/domain"
+	"bank-api/src/models"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -40,6 +43,14 @@ func Withdraw(c *gin.Context) {
 	database.Repo.UpdateAccount(account)
 
 	balance := domain.GetBalance(account)
+
+	events.BrokerInstance.Publish(models.TransactionEvent{
+		Type:      "withdraw",
+		AccountID: account.Id,
+		Amount:    req.Amount,
+		Balance:   balance,
+		Timestamp: time.Now(),
+	})
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Saque realizado com sucesso",

--- a/src/models/event.go
+++ b/src/models/event.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+type TransactionEvent struct {
+	Type        string    `json:"type"`
+	AccountID   int       `json:"account_id,omitempty"`
+	FromID      int       `json:"from_id,omitempty"`
+	ToID        int       `json:"to_id,omitempty"`
+	Amount      int       `json:"amount"`
+	Balance     int       `json:"balance,omitempty"`
+	FromBalance int       `json:"from_balance,omitempty"`
+	ToBalance   int       `json:"to_balance,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
## Summary
- add `TransactionEvent` struct to describe operations
- broadcast deposit, withdraw, and transfer actions through a simple broker
- stream published events to clients via `/events` SSE route

## Testing
- `timeout 30 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897c71aa50483249fe103c3c66b7422