### PR TITLE
Add docker-compose setup with simulator and dashboard

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,12 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server ./src
+
+FROM alpine:3.19
+WORKDIR /root/
+COPY --from=build /app/server ./server
+EXPOSE 8080
+CMD ["./server"]

--- a/Dockerfile.simulator
+++ b/Dockerfile.simulator
@@ -1,0 +1,11 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o simulator ./src/simulator
+
+FROM alpine:3.19
+WORKDIR /root/
+COPY --from=build /app/simulator ./simulator
+CMD ["./simulator"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ go run src/main.go
 ```
 The server will start on `localhost:8080` by default.
 
+### Docker Compose
+
+To run the API, load simulator and web dashboard together:
+
+```bash
+docker-compose up --build
+```
+
+The API is exposed on `localhost:8080` and the dashboard on `http://localhost:5173`.
+
 ## Examples
 
 ### Sequence Diagram

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    ports:
+      - "8080:8080"
+  simulator:
+    build:
+      context: .
+      dockerfile: Dockerfile.simulator
+    depends_on:
+      - api
+    environment:
+      BASE_URL: http://api:8080
+  dashboard:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api

--- a/src/simulator/main.go
+++ b/src/simulator/main.go
@@ -1,17 +1,25 @@
 package main
 
 import (
-	"bank-api/src/metrics"
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"log"
-	"net/http"
-	"sync"
-	"time"
+        "bank-api/src/metrics"
+        "bytes"
+        "encoding/json"
+        "fmt"
+        "log"
+        "net/http"
+        "os"
+        "sync"
+        "time"
 )
 
-const baseURL = "http://localhost:8080"
+var baseURL = getenv("BASE_URL", "http://localhost:8080")
+
+func getenv(key, fallback string) string {
+        if v := os.Getenv(key); v != "" {
+                return v
+        }
+        return fallback
+}
 
 func createAccount(owner string) (int, error) {
 	body, _ := json.Marshal(map[string]string{"owner": owner})

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,8 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
-      '/metrics': 'http://localhost:8080'
+      '/metrics': 'http://api:8080'
     }
   }
 });


### PR DESCRIPTION
## Summary
- allow simulator base URL to be configured via environment variable
- provide Dockerfiles and docker-compose to run API, simulator, and web dashboard
- adjust Vite config and README for container-friendly dashboard

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897befebf748324a6cedfc89a4c70c9