### PR TITLE
Decrease go version to be compatible with docker-compose

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: '1.20'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module bank-api
 
-go 1.24
+go 1.20
 
 require (
 	github.com/gin-gonic/gin v1.10.1


### PR DESCRIPTION
To fix this error in docker-compose:

```
 => ERROR [api build 4/6] RUN go mod download                              0.1s
------                                                                          
 > [api build 4/6] RUN go mod download:
0.096 go: go.mod requires go >= 1.24 (running go 1.21.13; GOTOOLCHAIN=local)
------
failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

I'm decreasing go version from 1.24 to 1.20.