### PR TITLE
feat: add time series request chart to dashboard

### DIFF
--- a/dev/dashboard/src/App.jsx
+++ b/dev/dashboard/src/App.jsx
@@ -1,36 +1,102 @@
-import React, { useEffect, useState } from 'react';
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend
+} from 'recharts';
+
+const COLORS = [
+  '#8884d8',
+  '#82ca9d',
+  '#ff7300',
+  '#ff0000',
+  '#00C49F',
+  '#FFBB28',
+  '#FF8042'
+];
 
 export default function App() {
   const [data, setData] = useState([]);
+  const [colorMap, setColorMap] = useState({});
+  const lastCount = useRef(0);
 
   useEffect(() => {
     const fetchMetrics = async () => {
       const res = await fetch('/metrics');
-      const json = await res.json();
-      const formatted = json.map(m => {
-        const name = m.endpoint || m.Endpoint;
-        const durStr = String(m.duration || m.Duration || '');
-        return {
-          name,
-          duration: parseFloat(durStr.replace(/[^0-9.]/g, ''))
-        };
+      const metrics = await res.json();
+      const newMetrics = metrics.slice(lastCount.current);
+      lastCount.current = metrics.length;
+
+      if (newMetrics.length === 0) return;
+
+      const now = Date.now();
+      const cutoff = now - 5 * 60 * 1000; // last 5 minutes
+      const newEndpoints = new Set();
+
+      setData(prev => {
+        const filtered = prev.filter(d => d.time >= cutoff);
+        let entry = filtered[filtered.length - 1];
+        if (!entry || now - entry.time >= 1000) {
+          entry = { time: now };
+          filtered.push(entry);
+        }
+
+        newMetrics.forEach(m => {
+          const ep = m.endpoint || m.Endpoint;
+          entry[ep] = (entry[ep] || 0) + 1;
+          newEndpoints.add(ep);
+        });
+
+        // assign colors for new endpoints
+        if (newEndpoints.size > 0) {
+          setColorMap(prevColors => {
+            const updated = { ...prevColors };
+            newEndpoints.forEach(ep => {
+              if (!updated[ep]) {
+                const color = COLORS[Object.keys(updated).length % COLORS.length];
+                updated[ep] = color;
+              }
+            });
+            return updated;
+          });
+        }
+
+        return filtered;
       });
-      setData(formatted);
     };
+
     fetchMetrics();
     const id = setInterval(fetchMetrics, 1000);
     return () => clearInterval(id);
   }, []);
 
+  const lines = Object.entries(colorMap).map(([ep, color]) => (
+    <Line
+      key={ep}
+      type="monotone"
+      dataKey={ep}
+      stroke={color}
+      dot={false}
+      isAnimationActive={false}
+    />
+  ));
+
   return (
     <div style={{ width: '100%', height: 400 }}>
-      <LineChart width={600} height={300} data={data}>
+      <LineChart width={800} height={300} data={data}>
         <CartesianGrid stroke="#ccc" />
-        <XAxis dataKey="name" />
-        <YAxis />
-        <Tooltip />
-        <Line type="monotone" dataKey="duration" stroke="#8884d8" />
+        <XAxis
+          dataKey="time"
+          tickFormatter={t => new Date(t).toLocaleTimeString()}
+        />
+        <YAxis allowDecimals={false} />
+        <Tooltip labelFormatter={t => new Date(t).toLocaleTimeString()} />
+        <Legend />
+        {lines}
       </LineChart>
     </div>
   );

--- a/dev/simulator/main.go
+++ b/dev/simulator/main.go
@@ -111,41 +111,41 @@ func randomOp(ids []int) {
 }
 
 func main() {
-        rand.Seed(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 
-        const (
-                numAccounts = 100
-                totalOps    = 10000
-                blockSize   = 100
-                blockPause  = 100 * time.Millisecond
-        )
+	const (
+		numAccounts = 100
+		totalOps    = 10000
+		blockSize   = 100
+		blockPause  = 100 * time.Millisecond
+	)
 
-        ids := make([]int, 0, numAccounts)
-        for i := 0; i < numAccounts; i++ {
-                owner := fmt.Sprintf("User%d", i+1)
-                id, err := createAccount(owner)
-                if err != nil {
-                        log.Fatalf("cannot create account %s: %v", owner, err)
-                }
-                ids = append(ids, id)
-                deposit(id, 1000)
-        }
+	ids := make([]int, 0, numAccounts)
+	for i := 0; i < numAccounts; i++ {
+		owner := fmt.Sprintf("User%d", i+1)
+		id, err := createAccount(owner)
+		if err != nil {
+			log.Fatalf("cannot create account %s: %v", owner, err)
+		}
+		ids = append(ids, id)
+		deposit(id, 1000)
+	}
 
-        for sent := 0; sent < totalOps; {
-                var wg sync.WaitGroup
-                for i := 0; i < blockSize && sent < totalOps; i++ {
-                        wg.Add(1)
-                        go func() {
-                                defer wg.Done()
-                                randomOp(ids)
-                        }()
-                        sent++
-                }
-                wg.Wait()
-                time.Sleep(blockPause)
-        }
+	var wg sync.WaitGroup
+	for sent := 0; sent < totalOps; {
+		for i := 0; i < blockSize && sent < totalOps; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				randomOp(ids)
+			}()
+			sent++
+		}
+		time.Sleep(blockPause)
+	}
 
-        for _, m := range metrics.List() {
-                log.Printf("%s status=%d duration=%s", m.Endpoint, m.Status, m.Duration)
-        }
+	wg.Wait()
+	for _, m := range metrics.List() {
+		log.Printf("%s status=%d duration=%s", m.Endpoint, m.Status, m.Duration)
+	}
 }

--- a/dev/simulator/main.go
+++ b/dev/simulator/main.go
@@ -114,10 +114,9 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	const (
-		numAccounts = 100
-		totalOps    = 10000
-		blockSize   = 100
-		blockPause  = 100 * time.Millisecond
+		numAccounts = 1000
+		totalOps    = 100000
+		blockSize   = 500
 	)
 
 	ids := make([]int, 0, numAccounts)
@@ -131,20 +130,37 @@ func main() {
 		deposit(id, 1000)
 	}
 
-	var wg sync.WaitGroup
-	for sent := 0; sent < totalOps; {
-		for i := 0; i < blockSize && sent < totalOps; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				randomOp(ids)
-			}()
-			sent++
+	opsThisBlock := func(sent, total, block int) int {
+		if total-sent < block {
+			return total - sent
 		}
-		time.Sleep(blockPause)
+
+		return block
 	}
 
-	wg.Wait()
+	blockDuration := 2 * time.Second
+	for sent := 0; sent < totalOps; {
+		n := opsThisBlock(sent, totalOps, blockSize)
+
+		interval := blockDuration / time.Duration(n)
+		ticker := time.NewTicker(interval)
+
+		var wgBlock sync.WaitGroup
+		wgBlock.Add(n)
+
+		for i := 0; i < n; i++ {
+			<-ticker.C
+			go func() {
+				defer wgBlock.Done()
+				randomOp(ids)
+			}()
+		}
+
+		wgBlock.Wait()
+		ticker.Stop()
+		sent += n
+	}
+
 	for _, m := range metrics.List() {
 		log.Printf("%s status=%d duration=%s", m.Endpoint, m.Status, m.Duration)
 	}


### PR DESCRIPTION
## Summary
- show request counts per endpoint over last five minutes
- color-code endpoint lines and provide legend

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897db41c3988324a3baa0babf6168bd