### PR TITLE
feat: add cors middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module bank-api
 go 1.20
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	github.com/stretchr/testify v1.10.0
+        github.com/gin-gonic/gin v1.10.1
+        github.com/gin-contrib/cors v1.5.1
+        github.com/stretchr/testify v1.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -88,3 +88,4 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
+

--- a/src/diplomat/middleware/cors.go
+++ b/src/diplomat/middleware/cors.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+// CORS configures cross-origin resource sharing.
+func CORS() gin.HandlerFunc {
+	return cors.New(cors.Config{
+		AllowOrigins:     []string{"http://localhost:5173"},
+		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type"},
+		AllowCredentials: true,
+		SuccessStatus:    http.StatusOK,
+	})
+}

--- a/src/main.go
+++ b/src/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bank-api/src/diplomat/database"
+	"bank-api/src/diplomat/middleware"
 	"bank-api/src/diplomat/routes"
 
 	"github.com/gin-gonic/gin"
@@ -10,6 +11,7 @@ import (
 func main() {
 	database.Init()
 	router := gin.Default()
+	router.Use(middleware.CORS())
 	routes.RegisterRoutes(router)
 	router.Run(":8080")
 }


### PR DESCRIPTION
## Summary
- add gin-contrib/cors dependency and configure middleware
- register CORS middleware before routes

## Testing
- `go mod tidy` *(fails: Forbidden when downloading github.com/gin-contrib/cors)*
- `go test ./...` *(fails: missing go.sum entry for module providing github.com/gin-contrib/cors)*

------
https://chatgpt.com/codex/tasks/task_e_6897f84ec7d08324944afb3499bbd557