### PR TITLE
Fix terraform plan step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,20 +156,31 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        shell: bash
         run: |
-          terraform plan -detailed-exitcode -out=tfplan
-          echo "exitcode=$?" >> $GITHUB_OUTPUT
+          set +e
+          terraform plan -input=false -no-color -detailed-exitcode -out=tfplan
+          status=$?
+          echo "exitcode=$status" >> $GITHUB_OUTPUT
+          # 1 = error -> fail the job
+          if [ "$status" -eq 1 ]; then
+            echo "::error::Terraform plan failed (exit 1)"
+            exit 1
+          fi
+          # 0 = no changes, 2 = changes -> continue
+          exit 0
 
       - name: Terraform Apply
         id: apply
-        if: github.event.inputs.action != 'plan' && (github.event.inputs.action == 'deploy' || github.ref == 'refs/heads/main')
+        if: steps.plan.outputs.exitcode == '2' && (github.event.inputs.action != 'plan' && (github.event.inputs.action == 'deploy' || github.ref == 'refs/heads/main'))
         run: |
-          terraform apply -auto-approve tfplan
+          terraform apply -input=false -no-color -auto-approve tfplan
           echo "instance_public_ip=$(terraform output -raw instance_public_ip)" >> $GITHUB_OUTPUT
 
       - name: Terraform Destroy
         if: github.event.inputs.action == 'destroy'
-        run: terraform destroy -auto-approve
+        run: terraform destroy -input=false -no-color -auto-approve
+
 
   deploy:
     name: Deploy Application


### PR DESCRIPTION
In the terraform plan step, we run:
`terraform plan -detailed-exitcode`

Terraform uses three distinct exit codes instead of the usual 0/1:

Exit Code	Meaning	When it happens
* 0 - The current infrastructure matches the configuration exactly.
* 1 -  Syntax error, missing provider, invalid variable, AWS permission issue, etc.
* 2 - Terraform detected that applying the plan will create, update, or destroy resources. This is not an error — it’s just “there is work to do”.

So what's happened:
* By default, GitHub Actions runs with set -e (fail on non-zero exit).
* Exit code 2 (changes) is a non-zero value, so the step was treated as a failure, even though it was just Terraform saying “yep, I have changes for you”.

The fix: if the return is 0 or 2, return 0 using bashcript.