### PR TITLE
Fix duplicate key pair problem

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,15 @@ jobs:
       - name: Terraform Init
         run: terraform init
 
+      - name: Import existing key pair if it exists
+        run: |
+          if aws ec2 describe-key-pairs --key-names core-banking-lab-key --region ${{ env.AWS_REGION }} >/dev/null 2>&1; then
+            echo "Key pair exists, importing to Terraform state..."
+            terraform import aws_key_pair.main core-banking-lab-key || echo "Key pair already in state or import failed"
+          else
+            echo "Key pair does not exist, Terraform will create it"
+          fi
+
       - name: Terraform Validate
         run: terraform validate
 


### PR DESCRIPTION
We're receiving this error after last run to deploy it to aws:

```
Error: importing EC2 Key Pair (core-banking-lab-key): operation error EC2: ImportKeyPair, https response error StatusCode: 400, RequestID: e86b2aed-f0d2-4432-b89f-5eebf361cb91, api error InvalidKeyPair.Duplicate: The keypair already exists
```

So, adding an aditional step to:
  1. Checks if the key pair exists in AWS using aws ec2 describe-key-pairs
  2. Imports it into Terraform state if it exists, preventing the duplicate
   error
  3. Handles gracefully if the key is already in state or import fails
  4. Allows normal creation if the key doesn't exist