### PR TITLE
Add kubernetes Python library installation to Ansible playbook

### DIFF
--- a/infra/ansible/playbooks/deploy.yml
+++ b/infra/ansible/playbooks/deploy.yml
@@ -60,6 +60,18 @@
         mode: '0600'
         remote_src: yes
 
+    - name: Install Python pip and kubernetes library
+      apt:
+        name: 
+          - python3-pip
+        state: present
+        update_cache: yes
+
+    - name: Install kubernetes Python library
+      pip:
+        name: kubernetes
+        state: present
+
     - name: Install Helm
       shell: |
         curl https://get.helm.sh/helm-v3.12.0-linux-arm64.tar.gz | tar -xzO linux-arm64/helm > /usr/local/bin/helm


### PR DESCRIPTION
- Install python3-pip and kubernetes Python library on target host
- Required for kubernetes.core.k8s Ansible module to function
- Resolves error: 'Failed to import the required Python library (kubernetes)'

🤖 Generated with [Claude Code](https://claude.ai/code)