### PR TITLE
Add GHCR image pull secrets for Kubernetes deployments

### DIFF
--- a/infra/ansible/playbooks/deploy.yml
+++ b/infra/ansible/playbooks/deploy.yml
@@ -89,6 +89,24 @@
       with_fileglob:
         - "../../../k8s/*.yaml"
 
+    - name: Create image pull secret for GHCR
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: ghcr-secret
+            namespace: banking
+          type: kubernetes.io/dockerconfigjson
+          data:
+            .dockerconfigjson: "{{ ('{ \"auths\": { \"ghcr.io\": { \"auth\": \"' + (github_actor + ':' + github_token) | b64encode + '\" } } }') | b64encode }}"
+        kubeconfig: /home/ubuntu/.kube/config
+      vars:
+        github_actor: "{{ ansible_env.GITHUB_ACTOR | default('fandangolas') }}"
+        github_token: "{{ ansible_env.GITHUB_TOKEN | default('') }}"
+      become_user: ubuntu
+
     - name: Apply Kubernetes manifests
       kubernetes.core.k8s:
         state: present

--- a/k8s/01-api-deployment.yaml
+++ b/k8s/01-api-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         app: banking-api
         component: backend
     spec:
+      imagePullSecrets:
+      - name: ghcr-secret
       containers:
       - name: banking-api
         image: banking-api:latest

--- a/k8s/02-dashboard-deployment.yaml
+++ b/k8s/02-dashboard-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         app: banking-dashboard
         component: frontend
     spec:
+      imagePullSecrets:
+      - name: ghcr-secret
       containers:
       - name: banking-dashboard
         image: banking-dashboard:latest


### PR DESCRIPTION
- Create ghcr-secret with GitHub credentials in Ansible playbook
- Add imagePullSecrets to API and Dashboard deployments
- Resolves 401 Unauthorized errors when pulling private images from GHCR
- Uses environment variables GITHUB_ACTOR and GITHUB_TOKEN for authentication

🤖 Generated with [Claude Code](https://claude.ai/code)