### PR TITLE
Fix CORS issues with relative URLs and complete proxy configuration

### DIFF
--- a/dev/dashboard/src/simulator.js
+++ b/dev/dashboard/src/simulator.js
@@ -1,4 +1,6 @@
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+// Use relative URLs to go through Vite proxy in development
+// In production, this would be configured differently
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 async function request(url, options = {}) {
   const res = await fetch(`${BASE_URL}${url}`, {

--- a/dev/dashboard/vite.config.js
+++ b/dev/dashboard/vite.config.js
@@ -6,7 +6,19 @@ export default defineConfig({
   server: {
     host: true,
     proxy: {
+      '/accounts': {
+        target: process.env.VITE_API_URL || 'http://banking-api-service:8080',
+        changeOrigin: true
+      },
       '/metrics': {
+        target: process.env.VITE_API_URL || 'http://banking-api-service:8080',
+        changeOrigin: true
+      },
+      '/prometheus': {
+        target: process.env.VITE_API_URL || 'http://banking-api-service:8080',
+        changeOrigin: true
+      },
+      '/events': {
         target: process.env.VITE_API_URL || 'http://banking-api-service:8080',
         changeOrigin: true
       }

--- a/src/main.go
+++ b/src/main.go
@@ -24,7 +24,7 @@ func main() {
 	// Initialize database
 	database.Init()
 
-	// Setup router with middleware - testing cors allowing everything in dev env
+	// Setup router with middleware - fixed CORS with relative URLs
 	router := gin.Default()
 	router.Use(middleware.CORS(cfg))
 	//router.Use(middleware.RateLimit(cfg))


### PR DESCRIPTION
## Summary
- Fixed CORS errors when dashboard tries to call the API
- Dashboard was making direct calls to `http://localhost:8080` causing cross-origin issues

## Browser Error Fixed
```
Requisição cross-origin bloqueada: A diretiva Same Origin (mesma origem) 
não permite a leitura do recurso remoto em http://localhost:8080/accounts 
(motivo: falha na requisição CORS)
```

## Root Cause
The `simulator.js` file was using an absolute URL (`http://localhost:8080`) which caused CORS issues when the dashboard runs on a different port/host in Kubernetes.

## Solution
1. **Changed simulator.js**: Use relative URLs (empty BASE_URL) instead of hardcoded localhost:8080
2. **Updated vite.config.js**: Added proxy configuration for all API endpoints
   - `/accounts` → proxied to API service
   - `/metrics` → proxied to API service  
   - `/prometheus` → proxied to API service
   - `/events` → proxied to API service

## How it Works
- Dashboard makes requests to relative URLs (e.g., `/accounts`)
- Vite dev server proxies these to `http://banking-api-service:8080`
- No CORS issues because the proxy runs server-side
- The browser sees everything coming from the same origin

## Testing
- Dashboard should now successfully make API calls without CORS errors
- All simulator operations (create account, deposit, withdraw, transfer) should work
- Metrics should load properly

🤖 Generated with [Claude Code](https://claude.ai/code)