### PR TITLE
Improve deployment triggers for K8s and infrastructure changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
       api-image: ${{ env.API_IMAGE }}
       dash-image: ${{ env.DASH_IMAGE }}
       should-build: ${{ steps.changes.outputs.app }}
+      should-deploy: ${{ steps.changes.outputs.app == 'true' || steps.changes.outputs.infra == 'true' }}
 
     steps:
       - name: Checkout code
@@ -59,6 +60,9 @@ jobs:
             app:
               - 'src/**'
               - 'dev/dashboard/**'
+            infra:
+              - 'k8s/**'
+              - 'infra/**'
               - 'go.mod'
               - 'go.sum'
               - 'Dockerfile.api'
@@ -232,7 +236,7 @@ jobs:
 
       - name: Terraform Apply
         id: apply
-        if: (steps.plan.outputs.exitcode == '2' || needs.build.outputs.should-build == 'true') && (github.event.inputs.action != 'plan' && (github.event.inputs.action == 'deploy' || github.ref == 'refs/heads/main'))
+        if: (steps.plan.outputs.exitcode == '2' || needs.build.outputs.should-deploy == 'true') && (github.event.inputs.action != 'plan' && (github.event.inputs.action == 'deploy' || github.ref == 'refs/heads/main'))
         run: |
           if [ "${{ steps.plan.outputs.exitcode }}" == "2" ]; then
             echo "Infrastructure changes detected - applying terraform plan"
@@ -252,7 +256,7 @@ jobs:
     name: Deploy Application
     runs-on: ubuntu-latest
     needs: [build, terraform]
-    if: needs.terraform.outputs.instance-ip && github.event.inputs.action != 'destroy' && (needs.build.outputs.should-build == 'true' || needs.terraform.result == 'success')
+    if: needs.terraform.outputs.instance-ip && github.event.inputs.action != 'destroy' && (needs.build.outputs.should-deploy == 'true' || needs.terraform.result == 'success')
     environment: ${{ github.event.inputs.environment || 'dev' }}
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Improve deployment workflow to properly handle K8s and infrastructure changes
- Ensure deployments happen even when only manifests or configs change

## Problem
The current workflow only builds new Docker images when `src/**` or `dev/dashboard/**` change. When only K8s manifests or Ansible playbooks change, the deployment might not proceed properly because `should-build` would be false.

## Solution
Added infrastructure change detection:
- New filter `infra` that tracks `k8s/**` and `infra/**` changes
- New output `should-deploy` that is true when app OR infra changes
- Updated job conditions to use `should-deploy` instead of `should-build`

## Benefits
Now deployments will properly trigger when:
- ✅ Application code changes (builds new images + deploys)
- ✅ Kubernetes manifests change (uses existing images + deploys)
- ✅ Ansible/Terraform configs change (uses existing images + deploys)
- ✅ Any combination of the above

This is especially important after merging the namespace fixes, as those only touch K8s and Ansible files.

🤖 Generated with [Claude Code](https://claude.ai/code)